### PR TITLE
Fix TransactionData's currencyExchange type

### DIFF
--- a/lib/data_models/nordigen_transaction_model.dart
+++ b/lib/data_models/nordigen_transaction_model.dart
@@ -56,7 +56,7 @@ class TransactionData {
         amount: fetchedMap['transactionAmount']['amount'] as String,
         currency: fetchedMap['transactionAmount']['currency'] as String,
       ),
-      currencyExchange: fetchedMap['currencyExchange'] as List<dynamic>?,
+      currencyExchange: fetchedMap['currencyExchange'] as Map<dynamic, dynamic>?,
       creditorName: fetchedMap['creditorName'] as String?,
       creditorAccount: fetchedMap['creditorAccount'] as Map<String, dynamic>?,
       creditorAgent: fetchedMap['creditorAgent'] as String?,
@@ -155,8 +155,8 @@ class TransactionData {
   /// Transaction amount details associated with this.
   final AmountData transactionAmount;
 
-  /// Array of Report Exchnage Rate.
-  final List<dynamic>? currencyExchange;
+  /// Map of Report Exchnage Rate.
+  final Map<dynamic, dynamic>? currencyExchange;
 
   /// Name of the Transaction creditor if a "Debited" transaction
   final String? creditorName;


### PR DESCRIPTION
Hi!

First of all, thank you for this great library! It made my work much easier.

While trying to retrieve the list of transactions from my account, I got this error in the `TransactionData` class: 

```
Unhandled exception:
type '_InternalLinkedHashMap<String, dynamic>' is not a subtype of type 'List<dynamic>?' in type cast
#0      new TransactionData.fromMap            package:nordigen_integration/data_models/nordigen_transaction_model.dart:59
```
The error comes from the type of the `currencyExchange` parameter of the class.

I did a quick fix on my end by changing the type from a `List<dynamic>?` to `Map<dynamic, dynamic>?`.

However, it would be better to go for a more restricted `Map`.