### PR TITLE
Update api base url

### DIFF
--- a/lib/extensions/accounts.dart
+++ b/lib/extensions/accounts.dart
@@ -23,7 +23,7 @@ extension NordigenAccountsEndpoints on NordigenAccountInfoAPI {
     assert(accountID.isNotEmpty);
     // Make GET request and fetch output.
     final dynamic fetchedData = await _nordigenGetter(
-      endpointUrl: 'https://ob.nordigen.com/api/v2/accounts/$accountID/',
+      endpointUrl: 'https://bankaccountdata.gocardless.com/api/v2/accounts/$accountID/',
     );
     // Form the received dynamic Map into AccountMetaData for convenience.
     return AccountMetaData.fromMap(fetchedData);
@@ -41,7 +41,7 @@ extension NordigenAccountsEndpoints on NordigenAccountInfoAPI {
     // Make GET request and fetch output.
     final dynamic fetchedData = await _nordigenGetter(
       endpointUrl:
-          'https://ob.nordigen.com/api/v2/accounts/$accountID/details/',
+          'https://bankaccountdata.gocardless.com/api/v2/accounts/$accountID/details/',
     );
     assert(fetchedData['account'] != null);
     // Form the recieved dynamic Map into BankAccountDetails for convenience.
@@ -61,7 +61,7 @@ extension NordigenAccountsEndpoints on NordigenAccountInfoAPI {
     // Make GET request and fetch output.
     final dynamic fetchedData = await _nordigenGetter(
       endpointUrl:
-          'https://ob.nordigen.com/api/v2/accounts/$accountID/transactions/',
+          'https://bankaccountdata.gocardless.com/api/v2/accounts/$accountID/transactions/',
     );
     // No Transactions retrieved case.
     if (fetchedData['transactions'] == null) {
@@ -97,7 +97,7 @@ extension NordigenAccountsEndpoints on NordigenAccountInfoAPI {
     // Make GET request and fetch output.
     final dynamic fetched = await _nordigenGetter(
       endpointUrl:
-          'https://ob.nordigen.com/api/v2/accounts/$accountID/balances/',
+          'https://bankaccountdata.gocardless.com/api/v2/accounts/$accountID/balances/',
     );
     final List<dynamic> fetchedData = fetched['balances'] ?? <dynamic>[];
     // Form the recieved dynamic Map into BankAccountDetails for convenience.

--- a/lib/extensions/accounts.dart
+++ b/lib/extensions/accounts.dart
@@ -23,7 +23,8 @@ extension NordigenAccountsEndpoints on NordigenAccountInfoAPI {
     assert(accountID.isNotEmpty);
     // Make GET request and fetch output.
     final dynamic fetchedData = await _nordigenGetter(
-      endpointUrl: 'https://bankaccountdata.gocardless.com/api/v2/accounts/$accountID/',
+      endpointUrl:
+          'https://bankaccountdata.gocardless.com/api/v2/accounts/$accountID/',
     );
     // Form the received dynamic Map into AccountMetaData for convenience.
     return AccountMetaData.fromMap(fetchedData);

--- a/lib/extensions/agreements.dart
+++ b/lib/extensions/agreements.dart
@@ -33,7 +33,8 @@ extension NordigenAgreementsEndpoints on NordigenAccountInfoAPI {
 
     // Make POST request and fetch output.
     final dynamic fetchedData = await _nordigenPoster(
-      endpointUrl: 'https://bankaccountdata.gocardless.com/api/v2/agreements/enduser/',
+      endpointUrl:
+          'https://bankaccountdata.gocardless.com/api/v2/agreements/enduser/',
       data: <String, dynamic>{
         // API accepts days as String
         'max_historical_days': maxHistoricalDays.toString(),

--- a/lib/extensions/agreements.dart
+++ b/lib/extensions/agreements.dart
@@ -33,7 +33,7 @@ extension NordigenAgreementsEndpoints on NordigenAccountInfoAPI {
 
     // Make POST request and fetch output.
     final dynamic fetchedData = await _nordigenPoster(
-      endpointUrl: 'https://ob.nordigen.com/api/v2/agreements/enduser/',
+      endpointUrl: 'https://bankaccountdata.gocardless.com/api/v2/agreements/enduser/',
       data: <String, dynamic>{
         // API accepts days as String
         'max_historical_days': maxHistoricalDays.toString(),
@@ -62,7 +62,7 @@ extension NordigenAgreementsEndpoints on NordigenAccountInfoAPI {
     // Make POST request and fetch output.
     final dynamic fetchedData = await _nordigenPoster(
       endpointUrl:
-          'https://ob.nordigen.com/api/v2/agreements/enduser/$endUserAgreementID/accept/',
+          'https://bankaccountdata.gocardless.com/api/v2/agreements/enduser/$endUserAgreementID/accept/',
       data: <String, dynamic>{
         'user_agent': userAgent,
         'ip_address': ipAddress,
@@ -82,7 +82,7 @@ extension NordigenAgreementsEndpoints on NordigenAccountInfoAPI {
     // Make GET request and fetch output.
     final dynamic fetchedData = await _nordigenGetter(
       endpointUrl:
-          'https://ob.nordigen.com/api/v2/agreements/enduser/$endUserAgreementID/',
+          'https://bankaccountdata.gocardless.com/api/v2/agreements/enduser/$endUserAgreementID/',
     );
     // Form the recieved dynamic Map into RequisitionModel for convenience.
     return EndUserAgreementModel.fromMap(fetchedData);
@@ -97,7 +97,7 @@ extension NordigenAgreementsEndpoints on NordigenAccountInfoAPI {
     // Make GET request and fetch output.
     final dynamic fetchedData = await _nordigenGetter(
       endpointUrl:
-          'https://ob.nordigen.com/api/v2/agreements/enduser/$endUserAgreementID/text/',
+          'https://bankaccountdata.gocardless.com/api/v2/agreements/enduser/$endUserAgreementID/text/',
     );
     return fetchedData;
   }
@@ -113,7 +113,7 @@ extension NordigenAgreementsEndpoints on NordigenAccountInfoAPI {
     // Make GET request and fetch output.
     final Map<String, dynamic> fetchedData = await _nordigenGetter(
       endpointUrl:
-          'https://ob.nordigen.com/api/v2/agreements/enduser/?limit=$limit&offset=$offset',
+          'https://bankaccountdata.gocardless.com/api/v2/agreements/enduser/?limit=$limit&offset=$offset',
     );
     final List<dynamic> fetchedEndUserAgreements = fetchedData['results'];
     // Form the recieved dynamic Map into EndUserAgreementModel for convenience.
@@ -133,6 +133,6 @@ extension NordigenAgreementsEndpoints on NordigenAccountInfoAPI {
   }) async =>
       await _nordigenDeleter(
         endpointUrl:
-            'https://ob.nordigen.com/api/v2/agreements/enduser/$endUserAgreementID/',
+            'https://bankaccountdata.gocardless.com/api/v2/agreements/enduser/$endUserAgreementID/',
       );
 }

--- a/lib/extensions/institutions.dart
+++ b/lib/extensions/institutions.dart
@@ -11,7 +11,7 @@ extension NordigenInstitutionsEndpoints on NordigenAccountInfoAPI {
     // Make GET request and fetch output.
     final List<dynamic> fetchedData = await _nordigenGetter(
           endpointUrl:
-              'https://ob.nordigen.com/api/v2/institutions/?country=$countryCode',
+              'https://bankaccountdata.gocardless.com/api/v2/institutions/?country=$countryCode',
         ) ??
         <dynamic>[];
     // Map the recieved List<dynamic> into List<Institution> Data Format.
@@ -29,7 +29,7 @@ extension NordigenInstitutionsEndpoints on NordigenAccountInfoAPI {
     // Make GET request and fetch output.
     final dynamic fetchedData = await _nordigenGetter(
       endpointUrl:
-          'https://ob.nordigen.com/api/v2/institutions/$institutionID/',
+          'https://bankaccountdata.gocardless.com/api/v2/institutions/$institutionID/',
     );
     // Form the recieved dynamic Map into RequisitionModel for convenience.
     return Institution.fromMap(fetchedData);

--- a/lib/extensions/requisitions.dart
+++ b/lib/extensions/requisitions.dart
@@ -35,7 +35,8 @@ extension NordigenRequisitionsEndpoints on NordigenAccountInfoAPI {
   }) async {
     // Make POST request and fetch output.
     final dynamic fetchedData = await _nordigenPoster(
-      endpointUrl: 'https://bankaccountdata.gocardless.com/api/v2/requisitions/',
+      endpointUrl:
+          'https://bankaccountdata.gocardless.com/api/v2/requisitions/',
       data: <String, dynamic>{
         'redirect': redirect,
         'institution_id': institutionID,

--- a/lib/extensions/requisitions.dart
+++ b/lib/extensions/requisitions.dart
@@ -35,7 +35,7 @@ extension NordigenRequisitionsEndpoints on NordigenAccountInfoAPI {
   }) async {
     // Make POST request and fetch output.
     final dynamic fetchedData = await _nordigenPoster(
-      endpointUrl: 'https://ob.nordigen.com/api/v2/requisitions/',
+      endpointUrl: 'https://bankaccountdata.gocardless.com/api/v2/requisitions/',
       data: <String, dynamic>{
         'redirect': redirect,
         'institution_id': institutionID,
@@ -58,7 +58,7 @@ extension NordigenRequisitionsEndpoints on NordigenAccountInfoAPI {
     // Make GET request and fetch output.
     final Map<String, dynamic> fetchedData = await _nordigenGetter(
       endpointUrl:
-          'https://ob.nordigen.com/api/v2/requisitions/?limit=$limit&offset=$offset',
+          'https://bankaccountdata.gocardless.com/api/v2/requisitions/?limit=$limit&offset=$offset',
     );
     final List<dynamic> fetchedRequisitions = fetchedData['results'];
     // Form the recieved dynamic Map into RequisitionModel for convenience.
@@ -78,7 +78,7 @@ extension NordigenRequisitionsEndpoints on NordigenAccountInfoAPI {
     // Make GET request and fetch output.
     final dynamic fetchedData = await _nordigenGetter(
       endpointUrl:
-          'https://ob.nordigen.com/api/v2/requisitions/$requisitionID/',
+          'https://bankaccountdata.gocardless.com/api/v2/requisitions/$requisitionID/',
     );
     // Form the recieved dynamic Map into RequisitionModel for convenience.
     return RequisitionModel.fromMap(fetchedData);
@@ -92,6 +92,6 @@ extension NordigenRequisitionsEndpoints on NordigenAccountInfoAPI {
   }) async =>
       await _nordigenDeleter(
         endpointUrl:
-            'https://ob.nordigen.com/api/v2/requisitions/$requisitionID/',
+            'https://bankaccountdata.gocardless.com/api/v2/requisitions/$requisitionID/',
       );
 }

--- a/lib/extensions/token.dart
+++ b/lib/extensions/token.dart
@@ -22,7 +22,7 @@ extension NordigenTokenEndpoints on NordigenAccountInfoAPI {
     };
     // Make POST request and fetch output.
     final http.Response response = await http.post(
-      Uri.parse('https://ob.nordigen.com/api/v2/token/new/'),
+      Uri.parse('https://bankaccountdata.gocardless.com/api/v2/token/new/'),
       headers: <String, String>{
         'Content-Type': 'application/json',
         'accept': 'application/json',
@@ -55,7 +55,7 @@ extension NordigenTokenEndpoints on NordigenAccountInfoAPI {
   }) async {
     // Make POST request and fetch output.
     final http.Response response = await http.post(
-      Uri.parse('https://ob.nordigen.com/api/v2/token/refresh/'),
+      Uri.parse('https://bankaccountdata.gocardless.com/api/v2/token/refresh/'),
       headers: _headers,
       body: json.encode(<String, String>{'refresh': refresh}),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,330 +5,385 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
+      url: "https://pub.dev"
     source: hosted
-    version: "46.0.0"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.6.0"
+    version: "6.4.1"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.2"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "8acabb8306b57a409bf4c83522065672ee13179297a6bb0cb9ead73948df7c76"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.7.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   http:
     dependency: "direct main"
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.13.5"
+    version: "0.13.6"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.7.1"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.16+1"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.5"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: "7ee446762c2c50b3bd4ea96fe13ffac69919352bd3b4b17bac3f3465edc58073"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.21.4"
+    version: "1.25.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.7.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: a75f83f14ad81d5fe4b3319710b90dec37da0e22612326b696c9e1b8f34bbf48
+      url: "https://pub.dev"
     source: hosted
-    version: "9.3.0"
+    version: "14.2.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: "1d8e795e2a8b3730c41b8a98a2dff2e0fb57ae6f0764a1c46ec5915387d257b2"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.4"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
Updated api base url.

Related GoCardless email:
Dear user,

The planned URL change we have initially informed you of several weeks ago is proceeding on 26.03.2024.
Please make sure the base URL of your integration with the GoCardless Bank Account Data API is https://bankaccountdata.gocardless.com/api/v2/
While this date may include some buffer, we cannot guarantee older URLs will work past this date.

If you are using any of our 4 official open-source libraries, they have been updated, published and can be found here:
https://developer.gocardless.com/bank-account-data/libraries
Take note that we take no responsibility for updating any unofficial or custom libraries. Check their code or contact the maintainer if you are in doubt.
