### PR TITLE
ci(security): harden Dart workflow

### DIFF
--- a/.github/workflows/build_format_test.yml
+++ b/.github/workflows/build_format_test.yml
@@ -11,18 +11,24 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   build_format_test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       # Note: This workflow uses the latest stable version of the Dart SDK.
       # You can specify other versions if desired, see documentation here:
       # https://github.com/dart-lang/setup-dart/blob/main/README.md
       # - uses: dart-lang/setup-dart@v1
-      - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603
+      - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603 # v1.0.0
 
       - name: Install dependencies
         run: dart pub get


### PR DESCRIPTION
## Summary

This PR closes CodeQL alert #1 by making the Dart workflow explicitly read-only and preventing checkout credentials from persisting. It preserves the workflow's triggers, Dart commands, environment, secret references, package metadata, and publishing behavior.

## Design Context

The workflow grants only `contents: read` to the test job and pins both setup actions to verified immutable revisions. No application or package code changes, and no new CI abstraction is introduced.

## Test Plan

- [x] Validate the workflow with actionlint 1.7.7 and `git diff --check`.
- [x] Assert exact trigger, command, environment, and secret-reference equivalence against `main`.
- [x] Verify upstream release provenance for both action revisions.
- [x] Scan the candidate tree and repository history with gitleaks.
- [x] Recreate the commit with GitHub's valid signature while preserving the exact reviewed tree `24087eef8bdf1d555c50b20d14c89da3c78ac5fd`.
- [x] Confirm exact-head Dart build, format, test, CodeQL, and GitGuardian checks pass.

The GitHub Actions run is the executable Dart oracle because Dart and Flutter are not installed in the local campaign environment.

## How to Review

Review the workflow permissions first, then confirm the immutable action pins and unchanged Dart commands in `.github/workflows/build_format_test.yml`.

## Related Issues

Closes CodeQL alert #1.

Generated with [Dhiman's Agentic Suite](https://github.com/Dhi13man)
