### PR TITLE
docs: fix public API references

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
       dart-dependencies:
         patterns:
           - "*"
+    ignore:
+      # lints 4+ drops compatibility with the package's supported Dart 2.x SDKs.
+      - dependency-name: lints
+        update-types:
+          - version-update:semver-major
     open-pull-requests-limit: 5
   - package-ecosystem: github-actions
     directory: /

--- a/lib/data_models/nordigen_other_data_models.dart
+++ b/lib/data_models/nordigen_other_data_models.dart
@@ -3,7 +3,7 @@ part of 'package:nordigen_integration/nordigen_integration.dart';
 /// Institution (Bank) Data Model for Nordigen
 ///
 /// Contains the [id] of the Institution, its [name], [bic],
-/// [totalTransactionDays] and the [countries] associated with the Institution.
+/// [transactionTotalDays] and the [countries] associated with the Institution.
 class Institution {
   const Institution({
     required this.id,

--- a/lib/data_models/nordigen_requisition_model.dart
+++ b/lib/data_models/nordigen_requisition_model.dart
@@ -2,7 +2,7 @@ part of 'package:nordigen_integration/nordigen_integration.dart';
 
 /// Requisition Model for Nordigen.
 ///
-/// Contains the [id] of the Requisition, its [status], end-user [agreements],
+/// Contains the [id] of the Requisition, its [status], end-user [agreement],
 /// the [redirectURL] to which it should redirect, [reference] ID if any,
 /// [accounts] associated, and the associated [institutionID].
 class RequisitionModel {
@@ -82,7 +82,7 @@ class RequisitionModel {
   /// Additional layer of unique ID defined by user.
   final String reference;
 
-  /// Agreements associated with the Requistion
+  /// Accounts associated with the Requisition.
   final List<String> accounts;
 
   /// [String] code of the Language of the requisition verification.

--- a/lib/nordigen_integration.dart
+++ b/lib/nordigen_integration.dart
@@ -1,3 +1,4 @@
+/// Dart client and typed models for GoCardless Bank Account Data.
 library nordigen_integration;
 
 import 'dart:convert';


### PR DESCRIPTION
## Why

The standards pass reached 160/160 on Pana, but Dartdoc still reported three broken or missing public-library references. Dependabot also proposed `lints` 6.x even though it requires Dart 3.8 while this package deliberately retains a Dart 2.12 SDK floor.

## What changed

- document the public library and correct two invalid Dartdoc references
- correct the requisition account-field description
- ignore only major `lints` updates; compatible minor and patch updates remain enabled

No runtime behavior or public API changes.

## Verification

- [x] Dart 3.12.2 format check
- [x] Dart 3.12.2 fatal analysis
- [x] 4/4 deterministic tests
- [x] Pana 160/160 with 0 Dartdoc warnings or errors
- [x] `dart pub publish --dry-run` with 0 warnings
- [x] Dependabot YAML parse and policy assertion
- [x] actionlint, Gitleaks, diff, and de-bloat review

## Tradeoffs

`lints` 4+ remains deferred until a deliberate SDK-floor change. This keeps the current compatibility contract without disabling safe minor or patch updates.

## How to review

1. Check the three Dartdoc corrections against the referenced fields.
2. Check the Dependabot ignore rule is limited to `lints` major versions.
3. Confirm the diff contains no executable behavior change.
