### PR TITLE
chore(release): prepare 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 # Releases
 
-## Unreleased
+## [2.0.0] - 30th July, 2026
 
-- **Breaking:** Require Dart 3.11 or later and remove the Dart 2.x lint holdback.
-- Correct the documented `getAccountBalances` return type to `Future<List<Balance>>`.
+- **Breaking:** Require Dart 3.11 or later, adopt `lints` 6.1, and apply the
+  Dart 3.11 formatter while preserving runtime behavior.
+- Harden CI with least-privilege permissions, immutable action pins, no exposed
+  banking credentials, fatal analysis, tests, and package publish validation.
+- Add Dependabot, OpenSSF Scorecard, security and conduct policies, issue forms,
+  and a pull-request template for maintained community and supply-chain checks.
+- Refresh the compatible dependency graph, fix analyzer-invalid test callbacks,
+  and remove the obsolete package-test screenshot.
+- Update package metadata and documentation for GoCardless Bank Account Data,
+  repair public API references, and document `getAccountBalances` as returning
+  `Future<List<Balance>>`.
 
 ## [1.7.7] - 31st March 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,11 +118,11 @@ Documentation fixes and more specific tests for DELETE requests.
 ## [1.2.5] - 14th May, 2021
 
 1. Implemented actual full `TransactionData` Model from API Documentation.
-2. Renamed `BankAccountModel` to `AccountModel` because of account schema discrepancies in the upstream documentation, now available in the [GoCardless endpoint reference](https://developer.gocardless.com/bank-account-data/endpoints/).
+2. Renamed `BankAccountModel` to `AccountModel` because of Account schema discrepency in documentation between <https://nordigen.com/en/docs/account-information/overview/parameters-and-responses/> and <https://nordigen.com/en/docs/account-information/output/accounts/>.
 3. Implemented `Balance` model from API Documentation.
 4. Temporary `getAccountBalancesTemporary` method of `NordigenAccountInfoAPI` class implemented that will be depreciated once the returned data format can be pinned down.
 5. Lint -> Pedantic.
-6. Todo: Resolve the account model discrepancy in the upstream endpoint schema.
+6. Todo: Resolve account model discrepency between <https://nordigen.com/en/docs/account-information/output/accounts/> and Schema given in <https://nordigen.com/en/docs/account-information/overview/parameters-and-responses/>
 
 ## [1.2.0] - 14th May, 2021
 
@@ -133,16 +133,16 @@ Documentation fixes and more specific tests for DELETE requests.
 
 ## [1.0.2] - 14th May, 2021
 
-Initial release supporting Nordigen's Account Information API, now documented in the [GoCardless Bank Account Data quick-start guide](https://developer.gocardless.com/bank-account-data/quick-start-guide/), and relevant serializable data models.
+Initial release supporting [Nordigen's Account Information API documentation](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) and relevant Data Models required to support it, in the form of Serializable Classes.
 
 Added EU PSD2 AISP keywords to package descriptions so people can find it easier. Unnecessary Flutter dependancy removed.
 
 ## [1.0.1] - 13th May, 2021
 
-Initial release supporting Nordigen's Account Information API, now documented in the [GoCardless Bank Account Data quick-start guide](https://developer.gocardless.com/bank-account-data/quick-start-guide/), and relevant serializable data models.
+Initial release supporting [Nordigen's Account Information API documentation](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) and relevant Data Models required to support it, in the form of Serializable Classes.
 
 Shortened Package description to follow dart conventions.
 
 ## [1.0.0] - 13th May, 2021
 
-Initial release supporting Nordigen's Account Information API, now documented in the [GoCardless Bank Account Data quick-start guide](https://developer.gocardless.com/bank-account-data/quick-start-guide/), and relevant serializable data models.
+Initial release supporting [Nordigen's Account Information API documentation](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) and relevant Data Models required to support it, in the form of Serializable Classes.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nordigen_integration
 description: Dart client and data models for the GoCardless Bank Account Data (formerly Nordigen) PSD2 API.
-version: 1.7.7
+version: 2.0.0
 homepage: https://github.com/Dhi13man/nordigen_integration/
 repository: https://github.com/Dhi13man/nordigen_integration/
 issue_tracker: https://github.com/Dhi13man/nordigen_integration/issues/


### PR DESCRIPTION
## Why

`main` now requires Dart 3.11, but the package manifest still identifies that breaking compatibility contract as `1.7.7`. Publishing under the old version would be rejected by pub.dev and would hide the consumer-visible SDK change.

## What changed

- set the package version to `2.0.0`
- replace `Unreleased` with dated release notes covering all four commits since pub.dev `1.7.7`
- restore every byte from `## [1.7.7]` onward to the published `1.7.7` baseline at `40a689fb`
- keep the 2026 GoCardless metadata/documentation refresh recorded only in the new `2.0.0` section

## Verification

- [x] Published changelog tail is byte-for-byte identical to `40a689fb` / pub.dev `1.7.7`
- [x] Published-tail SHA-256: `38addf8b2a89bc0d01e724edcc05e631daa1225c609351f938f81b84f95937e9`
- [x] Final diff scope is only `CHANGELOG.md` and `pubspec.yaml`
- [x] `dart format --output=none --set-exit-if-changed .` (22 files, 0 changed)
- [x] `dart analyze --fatal-infos` (no issues)
- [x] `EXEC_ENV=github_actions dart test` (4 passed)
- [x] `dart pub outdated` (no outdated packages)
- [x] `dart pub publish --dry-run` at exact head (0 warnings, 26 KB archive)
- [x] Pana `0.23.15` at exact head: `160/160`; dartdoc found 0 warnings and 0 errors
- [x] `markdownlint-cli2 CHANGELOG.md` with the project harness config (0 errors)
- [x] GitHub commit signature verified and exact-head CI green
- [x] No credentials, account identifiers, or personal data are included

## Compatibility and review notes

This is a major release because Dart 2 and Dart 3.0-3.10 consumers are no longer supported. Runtime behavior and public Dart APIs are otherwise unchanged. Review the version in `pubspec.yaml`, the new top section of `CHANGELOG.md`, and the published-history restoration; no tag, GitHub Release, or pub.dev publication is performed by this PR.

Generated with [Dhiman's Agentic Suite](https://github.com/Dhi13man)