### PR TITLE
docs: ship agent skill and release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Releases
 
-## [Unreleased]
+## [2.0.1] - 10th September, 2026
 
 - Ship an Agent Skill under `skills/` so `dart run skills@ get` installs
   the GoCardless account-link flow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Releases
 
+## [Unreleased]
+
+- Ship an Agent Skill under `skills/` so `dart run skills@ get` installs
+  the GoCardless account-link flow.
+
 ## [2.0.0] - 30th July, 2026
 
 - **Breaking:** Require Dart 3.11 or later, adopt `lints` 6.1, and apply the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ Thank you for improving the package. Before changing API behavior, review the
 - Use environment variables for opt-in live integration tests. The default test
   suite must remain safe to run without credentials.
 - Update `README.md` and `CHANGELOG.md` when users need to know about the change.
+- If you change the account-link flow, host, token handling, or method names,
+  update `skills/`.
 
 Run the same gates as CI before opening a pull request:
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ For API concepts and credentials, see the
 
 ## Usage Steps
 
+If an AI coding agent is writing this integration, run
+`dart run skills@ get` so it follows this client's GoCardless flow instead
+of retired Nordigen hosts.
+
 1. Read the [GoCardless Bank Account Data quick-start guide](https://developer.gocardless.com/bank-account-data/quick-start-guide/).
 
 2. Register and create user secrets as described in the [quick-start guide](https://developer.gocardless.com/bank-account-data/quick-start-guide/).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nordigen_integration
 description: Dart client and data models for the GoCardless Bank Account Data (formerly Nordigen) PSD2 API.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/Dhi13man/nordigen_integration/
 repository: https://github.com/Dhi13man/nordigen_integration/
 issue_tracker: https://github.com/Dhi13man/nordigen_integration/issues/

--- a/skills/nordigen-integration-account-link/SKILL.md
+++ b/skills/nordigen-integration-account-link/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: nordigen-integration-account-link
+description: >-
+  Use whenever writing, fixing, or reviewing Dart/Flutter code that uses
+  package:nordigen_integration, GoCardless Bank Account Data, Nordigen, PSD2,
+  open banking, requisitions, or bank transactions. Trigger on "Nordigen",
+  "GoCardless", "bank account data", "requisition", "end user agreement",
+  "list banks", "fetch transactions".
+---
+
+# nordigen_integration
+
+Dart client for **GoCardless Bank Account Data**. Types are still named
+`Nordigen*`. The live host is `https://bankaccountdata.gocardless.com`. Do not
+call `ob.nordigen.com` or `nordigen.com` API hosts; those are dead.
+
+## Secrets
+
+`secret_id` and `secret_key` come from environment or a secret store. Never
+commit, log, print, or embed them in widgets or tests. Use placeholders in
+examples.
+
+`NordigenAccountInfoAPI.fromSecret(secretID:, secretKey:)` keeps only the
+access JWT and drops `refresh`. For a process that outlives the access token,
+call `NordigenAccountInfoAPI.createAccessToken`, persist `refresh`, construct
+with `NordigenAccountInfoAPI(accessToken:)`, and later
+`refreshAccessToken(refresh:)`.
+
+HTTP failures throw `http.ClientException`, not a package exception type.
+
+## Link flow
+
+Skip a step and you get 403 or empty `accounts`. Order:
+
+1. `getInstitutionsForCountry(countryCode: 'gb')`: ISO 3166 two letters.
+2. `createEndUserAgreement(institutionID:)`: `accessScope` may only contain
+   `'balances'`, `'details'`, `'transactions'` (`ArgumentError` otherwise).
+3. `createRequisitionAndBuildLink(redirect:, institutionID:,
+   agreement: eua.id, reference: uniqueId)`.
+4. Send the end user to `requisition.link`. Do **not** call
+   `acceptEndUserAgreement` unless you have that user's `ipAddress` and
+   `userAgent`; it 403s otherwise.
+5. After redirect: `getEndUserAccountIDs(requisitionID: requisition.id)`.
+6. Per account id:
+   - `getAccountDetails`: IBAN, owner, currency
+   - `getAccountMetaData`: requisition account resource, not details
+   - `getAccountTransactions`: map keys `'booked'` and `'pending'`
+   - `getAccountBalances`: `List<Balance>`
+
+```dart
+import 'package:nordigen_integration/nordigen_integration.dart';
+
+final api = await NordigenAccountInfoAPI.fromSecret(
+  secretID: secretId,
+  secretKey: secretKey,
+);
+final bank = (await api.getInstitutionsForCountry(countryCode: 'gb')).first;
+final eua = await api.createEndUserAgreement(institutionID: bank.id);
+final requisition = await api.createRequisitionAndBuildLink(
+  redirect: redirectUrl,
+  institutionID: bank.id,
+  agreement: eua.id,
+  reference: reference,
+);
+// Open requisition.link, then:
+final accountIds = await api.getEndUserAccountIDs(
+  requisitionID: requisition.id,
+);
+```


### PR DESCRIPTION
## Why

Agents still target retired Nordigen hosts and skip the GoCardless link order. Banking credentials get pasted into examples. This skill encodes those failure modes, version-locked with the package, instead of restating the README.

## What changed

Consumers who run `dart run skills@ get` install `nordigen-integration-account-link`. README notes the command. CHANGELOG Unreleased. CONTRIBUTING requires updating `skills/` when the flow changes.

## Verification

- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze`
- [x] `EXEC_ENV=github_actions dart test`
- [x] `dart pub publish --dry-run` includes `skills/nordigen-integration-account-link/SKILL.md`
- [x] No credentials, account identifiers, or personal data are included
- [x] Path-dependent `dart run skills@ get --all --agent generic` installed the skill
- [x] markdownlint-cli2 on `SKILL.md`: 0 errors

## Compatibility and review notes

No Dart API change. `fromSecret` still drops `refresh`; the skill documents that instead of changing it.

Generated with [Dhiman's Agentic Suite](https://github.com/Dhi13man)
