### PR TITLE
docs: add community standards and README SEO

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+---
+name: Issue
+about: Report a bug or request a change
+---
+
+## What happened or what you want
+
+<!-- One or two sentences. -->
+
+## Steps to reproduce (bugs)
+
+1.
+2.
+3.
+
+## Expected vs actual
+
+## Environment
+
+- OS:
+- Version or commit of nordigen_integration:


### PR DESCRIPTION
## Summary

GitHub community standards on the default branch were incomplete, so the public community checklist could not reach 100%. This PR adds the missing community-health files and tightens the README so the project's purpose, install path, and contribution route are obvious.

No runtime behavior changes. No version bump and no registry publish.

## Test Plan

- [ ] CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md, license, issue templates, and PR template are on the branch
- [ ] README lead states what the project is and who it is for
- [ ] Diff contains no product-code or lockfile changes except `indentable_reorderable_list` package.json description/keywords

## How to Review

Start with the README lead, then `.github` templates. Policy files share wording across repos; names and security URLs are repo-specific.

Generated with [Dhiman's Agentic Suite](https://github.com/Dhi13man)
